### PR TITLE
Add error feedback for invalid JSON

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import {
   Flex,
   Stack,
   Code,
+  Alert,
+  AlertIcon,
   useColorModeValue,
   IconButton,
   useColorMode
@@ -24,6 +26,7 @@ function App() {
   const [selectedField, setSelectedField] = useState<JsonPath | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
+  const [errorMessage, setErrorMessage] = useState('');
 
   // Cores do tema
   const bgColor = useColorModeValue('#f7f7fb', 'gray.900');
@@ -84,8 +87,10 @@ function App() {
       setJsonData(parsedData);
       setPaths(newPaths);
       setCollapsedNodes(new Set());
+      setErrorMessage('');
     } catch (error) {
       console.error('Erro ao analisar JSON:', error);
+      setErrorMessage('JSON inválido');
     }
   };
 
@@ -379,6 +384,12 @@ function App() {
                   _hover={{ borderColor: 'purple.400' }}
                   _focus={{ borderColor: 'purple.400', boxShadow: '0 0 0 1px var(--chakra-colors-purple-400)' }}
                 />
+                {errorMessage && (
+                  <Alert status="error" mt={2} borderRadius="md">
+                    <AlertIcon />
+                    {errorMessage}
+                  </Alert>
+                )}
                 <Button
                   mt={4}
                   colorScheme="purple"


### PR DESCRIPTION
## Summary
- show parsing errors in App by storing errorMessage state
- reset error message on successful parsing
- display Alert under the textarea if JSON is invalid

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6856b199fcd48324a510a6eefbc1dc7b