### PR TITLE
Refactor UI into components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,15 +6,16 @@ import {
   Text,
   Textarea,
   Button,
-  Input,
   Flex,
   Stack,
-  Code,
   useColorModeValue,
   IconButton,
   useColorMode
 } from '@chakra-ui/react';
-import { ChevronDownIcon, ChevronRightIcon, SunIcon, MoonIcon } from '@chakra-ui/icons';
+import { SunIcon, MoonIcon } from '@chakra-ui/icons';
+import JsonTree from './components/JsonTree';
+import MappingPanel from './components/MappingPanel';
+import SearchInput from './components/SearchInput';
 import type { JsonPath } from './types/json';
 
 function App() {
@@ -31,8 +32,6 @@ function App() {
   const textColor = useColorModeValue('gray.900', 'gray.100');
   const secondaryTextColor = useColorModeValue('gray.600', 'gray.400');
   const borderColor = useColorModeValue('gray.200', 'gray.700');
-  const hoverBgColor = useColorModeValue('gray.100', 'gray.700');
-  const codeBgColor = useColorModeValue('gray.100', 'gray.700');
 
   const { colorMode, toggleColorMode } = useColorMode();
 
@@ -108,215 +107,6 @@ function App() {
     });
   };
 
-  // Função para renderizar apenas os caminhos que correspondem à busca
-  const renderFilteredJson = (obj: any, searchTerm: string) => {
-    if (!searchTerm) return renderJsonNode(obj);
-
-    const matchingPaths = paths.filter(p => 
-      p.caminho.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      String(p.valor).toLowerCase().includes(searchTerm.toLowerCase()) ||
-      p.nome.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-
-    if (matchingPaths.length === 0) {
-      return (
-        <Text color={secondaryTextColor} textAlign="center">
-          Nenhum resultado encontrado
-        </Text>
-      );
-    }
-
-    return (
-      <Stack spacing={2}>
-        {matchingPaths.map((path) => (
-          <Box
-            key={path.caminho}
-            p={2}
-            bg={cardBgColor}
-            borderRadius="md"
-            border="1px solid"
-            borderColor={borderColor}
-            _hover={{ bg: hoverBgColor }}
-            cursor="pointer"
-            onClick={() => handleFieldSelect(path.caminho)}
-          >
-            <Flex direction="column" gap={1}>
-              <Text fontSize="sm" color={textColor} fontWeight="bold">
-                {path.nome}
-              </Text>
-              <Text fontSize="xs" color={secondaryTextColor}>
-                Caminho: {path.caminho}
-              </Text>
-              <Flex align="center" gap={2}>
-                <Text fontSize="xs" color={textColor}>
-                  Valor: {String(path.valor)}
-                </Text>
-                <Code fontSize="xs" bg={codeBgColor} color={textColor}>
-                  {path.tipo}
-                </Code>
-              </Flex>
-            </Flex>
-          </Box>
-        ))}
-      </Stack>
-    );
-  };
-
-  // Adiciona um wrapper para desenhar as linhas da árvore
-  const TreeLineWrapper = ({ children, showLine, isLast }: { children: React.ReactNode, showLine: boolean, isLast: boolean }) => (
-    <Box position="relative" pl={4}>
-      {showLine && (
-        <Box
-          position="absolute"
-          top={0}
-          left={0}
-          h="100%"
-          w="16px"
-          zIndex={0}
-        >
-          {/* Linha vertical */}
-          <Box
-            position="absolute"
-            left="7px"
-            top={isLast ? '16px' : 0}
-            bottom={isLast ? 'auto' : 0}
-            h={isLast ? '16px' : '100%'}
-            w="2px"
-            bg={borderColor}
-          />
-        </Box>
-      )}
-      {children}
-    </Box>
-  );
-
-  // Ajusta renderJsonNode para usar o wrapper e desenhar as linhas
-  const renderJsonNode = (obj: any, level = 0, currentPath = '') => {
-    if (!obj || typeof obj !== 'object') return null;
-
-    if (Array.isArray(obj)) {
-      return obj.map((item, index) => {
-        const path = currentPath ? `${currentPath}[${index}]` : `[${index}]`;
-        const isObject = typeof item === 'object' && item !== null;
-        const indent = level * 16;
-        const isCollapsed = collapsedNodes.has(path);
-        const last = index === obj.length - 1;
-
-        return (
-          <TreeLineWrapper key={path} showLine={level > 0} isLast={last}>
-            <Box ml={`${indent}px`}>
-              <Flex
-                align="center"
-                py={1}
-                px={2}
-                _hover={{ bg: hoverBgColor }}
-                cursor="pointer"
-                onClick={() => handleFieldSelect(path)}
-                borderBottom="1px solid"
-                borderColor={borderColor}
-                position="relative"
-                zIndex={1}
-              >
-                {isObject && (
-                  <IconButton
-                    aria-label={isCollapsed ? "Expandir" : "Recolher"}
-                    icon={isCollapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
-                    size="xs"
-                    variant="ghost"
-                    color={textColor}
-                    mr={1}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleCollapse(path);
-                    }}
-                  />
-                )}
-                <Text fontSize="sm" color={textColor}>
-                  [{index}]
-                </Text>
-                {!isObject && (
-                  <>
-                    <Text fontSize="sm" color={secondaryTextColor} mx={2}>:</Text>
-                    <Text fontSize="sm" color={textColor}>{String(item)}</Text>
-                    <Code ml={2} fontSize="xs" bg={codeBgColor} color={textColor}>
-                      {typeof item}
-                    </Code>
-                  </>
-                )}
-                {isObject && (
-                  <Text fontSize="sm" color={secondaryTextColor} ml={2}>
-                    {Array.isArray(item) ? `[${item.length} itens]` : `{${Object.keys(item).length} campos}`}
-                  </Text>
-                )}
-              </Flex>
-              {isObject && !isCollapsed && renderJsonNode(item, level + 1, path)}
-            </Box>
-          </TreeLineWrapper>
-        );
-      });
-    }
-
-    const entries = Object.entries(obj);
-    return entries.map(([key, value], idx) => {
-      const path = currentPath ? `${currentPath}.${key}` : key;
-      const isObject = typeof value === 'object' && value !== null;
-      const indent = level * 16;
-      const isCollapsed = collapsedNodes.has(path);
-      const last = idx === entries.length - 1;
-
-      return (
-        <TreeLineWrapper key={path} showLine={level > 0} isLast={last}>
-          <Box ml={`${indent}px`}>
-            <Flex
-              align="center"
-              py={1}
-              px={2}
-              _hover={{ bg: hoverBgColor }}
-              cursor="pointer"
-              onClick={() => handleFieldSelect(path)}
-              borderBottom="1px solid"
-              borderColor={borderColor}
-              position="relative"
-              zIndex={1}
-            >
-              {isObject && (
-                <IconButton
-                  aria-label={isCollapsed ? "Expandir" : "Recolher"}
-                  icon={isCollapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
-                  size="xs"
-                  variant="ghost"
-                  color={textColor}
-                  mr={1}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleCollapse(path);
-                  }}
-                />
-              )}
-              <Text fontSize="sm" color={textColor}>
-                {key}
-              </Text>
-              {!isObject && (
-                <>
-                  <Text fontSize="sm" color={secondaryTextColor} mx={2}>:</Text>
-                  <Text fontSize="sm" color={textColor}>{String(value)}</Text>
-                  <Code ml={2} fontSize="xs" bg={codeBgColor} color={textColor}>
-                    {typeof value}
-                  </Code>
-                </>
-              )}
-              {isObject && (
-                <Text fontSize="sm" color={secondaryTextColor} ml={2}>
-                  {Array.isArray(value) ? `[${value.length} itens]` : `{${Object.keys(value).length} campos}`}
-                </Text>
-              )}
-            </Flex>
-            {isObject && !isCollapsed && renderJsonNode(value, level + 1, path)}
-          </Box>
-        </TreeLineWrapper>
-      );
-    });
-  };
 
   return (
     <Box minH="100vh" position="relative">
@@ -389,78 +179,21 @@ function App() {
                 </Button>
               </Box>
 
-              <Box bg={cardBgColor} p={4} borderRadius="lg" shadow="lg" w="100%" border="1px solid" borderColor={borderColor}>
-                <Heading size="sm" mb={4} color={textColor}>Mapeamento do Campo Selecionado</Heading>
-                {selectedField ? (
-                  <Stack>
-                    <Box>
-                      <Text fontSize="sm" fontWeight="semibold" color={textColor}>
-                        Nome do Campo:
-                      </Text>
-                      <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
-                        {selectedField.nome}
-                      </Code>
-                    </Box>
-
-                    <Box>
-                      <Text fontSize="sm" fontWeight="semibold" color={textColor}>
-                        Tipo:
-                      </Text>
-                      <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs">
-                        {selectedField.tipo}
-                      </Code>
-                    </Box>
-
-                    <Box>
-                      <Text fontSize="sm" fontWeight="semibold" color={textColor}>
-                        Valor:
-                      </Text>
-                      <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
-                        {String(selectedField.valor)}
-                      </Code>
-                    </Box>
-
-                    <Box>
-                      <Text fontSize="sm" fontWeight="semibold" color={textColor}>
-                        Caminho:
-                      </Text>
-                      <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
-                        {selectedField.caminho}
-                      </Code>
-                    </Box>
-
-                    <Box>
-                      <Text fontSize="sm" fontWeight="semibold" color={textColor}>
-                        Mapeamento Clint:
-                      </Text>
-                      <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
-                        {selectedField.caminho.replace(/^body\./, '')}
-                      </Code>
-                    </Box>
-                  </Stack>
-                ) : (
-                  <Text color={secondaryTextColor} textAlign="center">
-                    Nenhum campo selecionado
-                  </Text>
-                )}
-              </Box>
+              <MappingPanel field={selectedField} />
             </Stack>
 
             <Stack flex={1}>
-              <Input
-                placeholder="🔍 Buscar campo..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                size="sm"
-                bg={cardBgColor}
-                color={textColor}
-                borderColor={borderColor}
-                _hover={{ borderColor: 'purple.400' }}
-                _focus={{ borderColor: 'purple.400', boxShadow: '0 0 0 1px var(--chakra-colors-purple-400)' }}
-              />
+              <SearchInput value={searchTerm} onChange={setSearchTerm} />
               <Box bg={cardBgColor} p={4} borderRadius="lg" shadow="lg" w="100%" h="600px" overflowY="auto" border="1px solid" borderColor={borderColor}>
                 {jsonData ? (
-                  renderFilteredJson(jsonData, searchTerm)
+                  <JsonTree
+                    data={jsonData}
+                    paths={paths}
+                    search={searchTerm}
+                    collapsedNodes={collapsedNodes}
+                    toggleCollapse={toggleCollapse}
+                    onSelect={handleFieldSelect}
+                  />
                 ) : (
                   <Text color={secondaryTextColor} textAlign="center">
                     Nenhum JSON para exibir

--- a/src/components/JsonTree.tsx
+++ b/src/components/JsonTree.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import {
+  Box,
+  Flex,
+  Text,
+  Stack,
+  Code,
+  IconButton,
+  useColorModeValue
+} from '@chakra-ui/react';
+import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import type { JsonPath } from '../types/json';
+
+interface JsonTreeProps {
+  data: any;
+  paths: JsonPath[];
+  search: string;
+  collapsedNodes: Set<string>;
+  toggleCollapse: (path: string) => void;
+  onSelect: (path: string) => void;
+}
+
+const JsonTree: React.FC<JsonTreeProps> = ({
+  data,
+  paths,
+  search,
+  collapsedNodes,
+  toggleCollapse,
+  onSelect
+}) => {
+  const cardBgColor = useColorModeValue('white', 'gray.800');
+  const textColor = useColorModeValue('gray.900', 'gray.100');
+  const secondaryTextColor = useColorModeValue('gray.600', 'gray.400');
+  const borderColor = useColorModeValue('gray.200', 'gray.700');
+  const hoverBgColor = useColorModeValue('gray.100', 'gray.700');
+  const codeBgColor = useColorModeValue('gray.100', 'gray.700');
+
+  const TreeLineWrapper = ({
+    children,
+    showLine,
+    isLast
+  }: {
+    children: React.ReactNode;
+    showLine: boolean;
+    isLast: boolean;
+  }) => (
+    <Box position="relative" pl={4}>
+      {showLine && (
+        <Box position="absolute" top={0} left={0} h="100%" w="16px" zIndex={0}>
+          <Box
+            position="absolute"
+            left="7px"
+            top={isLast ? '16px' : 0}
+            bottom={isLast ? 'auto' : 0}
+            h={isLast ? '16px' : '100%'}
+            w="2px"
+            bg={borderColor}
+          />
+        </Box>
+      )}
+      {children}
+    </Box>
+  );
+
+  const renderJsonNode = (obj: any, level = 0, currentPath = ''): React.ReactNode => {
+    if (!obj || typeof obj !== 'object') return null;
+
+    if (Array.isArray(obj)) {
+      return obj.map((item, index) => {
+        const path = currentPath ? `${currentPath}[${index}]` : `[${index}]`;
+        const isObject = typeof item === 'object' && item !== null;
+        const indent = level * 16;
+        const isCollapsed = collapsedNodes.has(path);
+        const last = index === obj.length - 1;
+
+        return (
+          <TreeLineWrapper key={path} showLine={level > 0} isLast={last}>
+            <Box ml={`${indent}px`}>
+              <Flex
+                align="center"
+                py={1}
+                px={2}
+                _hover={{ bg: hoverBgColor }}
+                cursor="pointer"
+                onClick={() => onSelect(path)}
+                borderBottom="1px solid"
+                borderColor={borderColor}
+                position="relative"
+                zIndex={1}
+              >
+                {isObject && (
+                  <IconButton
+                    aria-label={isCollapsed ? 'Expandir' : 'Recolher'}
+                    icon={isCollapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
+                    size="xs"
+                    variant="ghost"
+                    color={textColor}
+                    mr={1}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleCollapse(path);
+                    }}
+                  />
+                )}
+                <Text fontSize="sm" color={textColor}>
+                  [{index}]
+                </Text>
+                {!isObject && (
+                  <>
+                    <Text fontSize="sm" color={secondaryTextColor} mx={2}>
+                      :
+                    </Text>
+                    <Text fontSize="sm" color={textColor}>
+                      {String(item)}
+                    </Text>
+                    <Code ml={2} fontSize="xs" bg={codeBgColor} color={textColor}>
+                      {typeof item}
+                    </Code>
+                  </>
+                )}
+                {isObject && (
+                  <Text fontSize="sm" color={secondaryTextColor} ml={2}>
+                    {Array.isArray(item)
+                      ? `[${item.length} itens]`
+                      : `{${Object.keys(item).length} campos}`}
+                  </Text>
+                )}
+              </Flex>
+              {isObject && !isCollapsed && renderJsonNode(item, level + 1, path)}
+            </Box>
+          </TreeLineWrapper>
+        );
+      });
+    }
+
+    const entries = Object.entries(obj);
+    return entries.map(([key, value], idx) => {
+      const path = currentPath ? `${currentPath}.${key}` : key;
+      const isObject = typeof value === 'object' && value !== null;
+      const indent = level * 16;
+      const isCollapsed = collapsedNodes.has(path);
+      const last = idx === entries.length - 1;
+
+      return (
+        <TreeLineWrapper key={path} showLine={level > 0} isLast={last}>
+          <Box ml={`${indent}px`}>
+            <Flex
+              align="center"
+              py={1}
+              px={2}
+              _hover={{ bg: hoverBgColor }}
+              cursor="pointer"
+              onClick={() => onSelect(path)}
+              borderBottom="1px solid"
+              borderColor={borderColor}
+              position="relative"
+              zIndex={1}
+            >
+              {isObject && (
+                <IconButton
+                  aria-label={isCollapsed ? 'Expandir' : 'Recolher'}
+                  icon={isCollapsed ? <ChevronRightIcon /> : <ChevronDownIcon />}
+                  size="xs"
+                  variant="ghost"
+                  color={textColor}
+                  mr={1}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleCollapse(path);
+                  }}
+                />
+              )}
+              <Text fontSize="sm" color={textColor}>
+                {key}
+              </Text>
+              {!isObject && (
+                <>
+                  <Text fontSize="sm" color={secondaryTextColor} mx={2}>
+                    :
+                  </Text>
+                  <Text fontSize="sm" color={textColor}>
+                    {String(value)}
+                  </Text>
+                  <Code ml={2} fontSize="xs" bg={codeBgColor} color={textColor}>
+                    {typeof value}
+                  </Code>
+                </>
+              )}
+              {isObject && (
+                <Text fontSize="sm" color={secondaryTextColor} ml={2}>
+                  {Array.isArray(value)
+                    ? `[${value.length} itens]`
+                    : `{${Object.keys(value).length} campos}`}
+                </Text>
+              )}
+            </Flex>
+            {isObject && !isCollapsed && renderJsonNode(value, level + 1, path)}
+          </Box>
+        </TreeLineWrapper>
+      );
+    });
+  };
+
+  const renderFilteredJson = (obj: any, term: string) => {
+    if (!term) return renderJsonNode(obj);
+
+    const matchingPaths = paths.filter(
+      (p) =>
+        p.caminho.toLowerCase().includes(term.toLowerCase()) ||
+        String(p.valor).toLowerCase().includes(term.toLowerCase()) ||
+        p.nome.toLowerCase().includes(term.toLowerCase())
+    );
+
+    if (matchingPaths.length === 0) {
+      return (
+        <Text color={secondaryTextColor} textAlign="center">
+          Nenhum resultado encontrado
+        </Text>
+      );
+    }
+
+    return (
+      <Stack spacing={2}>
+        {matchingPaths.map((path) => (
+          <Box
+            key={path.caminho}
+            p={2}
+            bg={cardBgColor}
+            borderRadius="md"
+            border="1px solid"
+            borderColor={borderColor}
+            _hover={{ bg: hoverBgColor }}
+            cursor="pointer"
+            onClick={() => onSelect(path.caminho)}
+          >
+            <Flex direction="column" gap={1}>
+              <Text fontSize="sm" color={textColor} fontWeight="bold">
+                {path.nome}
+              </Text>
+              <Text fontSize="xs" color={secondaryTextColor}>
+                Caminho: {path.caminho}
+              </Text>
+              <Flex align="center" gap={2}>
+                <Text fontSize="xs" color={textColor}>
+                  Valor: {String(path.valor)}
+                </Text>
+                <Code fontSize="xs" bg={codeBgColor} color={textColor}>
+                  {path.tipo}
+                </Code>
+              </Flex>
+            </Flex>
+          </Box>
+        ))}
+      </Stack>
+    );
+  };
+
+  return <>{data && renderFilteredJson(data, search)}</>;
+};
+
+export default JsonTree;

--- a/src/components/MappingPanel.tsx
+++ b/src/components/MappingPanel.tsx
@@ -1,0 +1,73 @@
+import { Box, Code, Heading, Stack, Text, useColorModeValue } from '@chakra-ui/react';
+import React from 'react';
+import type { JsonPath } from '../types/json';
+
+interface MappingPanelProps {
+  field: JsonPath | null;
+}
+
+const MappingPanel: React.FC<MappingPanelProps> = ({ field }) => {
+  const cardBgColor = useColorModeValue('white', 'gray.800');
+  const textColor = useColorModeValue('gray.900', 'gray.100');
+  const secondaryTextColor = useColorModeValue('gray.600', 'gray.400');
+  const borderColor = useColorModeValue('gray.200', 'gray.700');
+  const codeBgColor = useColorModeValue('gray.100', 'gray.700');
+
+  return (
+    <Box bg={cardBgColor} p={4} borderRadius="lg" shadow="lg" w="100%" border="1px solid" borderColor={borderColor}>
+      <Heading size="sm" mb={4} color={textColor}>Mapeamento do Campo Selecionado</Heading>
+      {field ? (
+        <Stack>
+          <Box>
+            <Text fontSize="sm" fontWeight="semibold" color={textColor}>
+              Nome do Campo:
+            </Text>
+            <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
+              {field.nome}
+            </Code>
+          </Box>
+
+          <Box>
+            <Text fontSize="sm" fontWeight="semibold" color={textColor}>
+              Tipo:
+            </Text>
+            <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs">
+              {field.tipo}
+            </Code>
+          </Box>
+
+          <Box>
+            <Text fontSize="sm" fontWeight="semibold" color={textColor}>
+              Valor:
+            </Text>
+            <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
+              {String(field.valor)}
+            </Code>
+          </Box>
+
+          <Box>
+            <Text fontSize="sm" fontWeight="semibold" color={textColor}>
+              Caminho:
+            </Text>
+            <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
+              {field.caminho}
+            </Code>
+          </Box>
+
+          <Box>
+            <Text fontSize="sm" fontWeight="semibold" color={textColor}>
+              Mapeamento Clint:
+            </Text>
+            <Code p={1} bg={codeBgColor} color={textColor} fontSize="xs" whiteSpace="pre-wrap" wordBreak="break-all">
+              {field.caminho.replace(/^body\./, '')}
+            </Code>
+          </Box>
+        </Stack>
+      ) : (
+        <Text color={secondaryTextColor} textAlign="center">Nenhum campo selecionado</Text>
+      )}
+    </Box>
+  );
+};
+
+export default MappingPanel;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,0 +1,29 @@
+import { Input, useColorModeValue } from '@chakra-ui/react';
+import React from 'react';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const SearchInput: React.FC<SearchInputProps> = ({ value, onChange }) => {
+  const cardBgColor = useColorModeValue('white', 'gray.800');
+  const textColor = useColorModeValue('gray.900', 'gray.100');
+  const borderColor = useColorModeValue('gray.200', 'gray.700');
+
+  return (
+    <Input
+      placeholder="🔍 Buscar campo..."
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      size="sm"
+      bg={cardBgColor}
+      color={textColor}
+      borderColor={borderColor}
+      _hover={{ borderColor: 'purple.400' }}
+      _focus={{ borderColor: 'purple.400', boxShadow: '0 0 0 1px var(--chakra-colors-purple-400)' }}
+    />
+  );
+};
+
+export default SearchInput;


### PR DESCRIPTION
## Summary
- create `src/components` folder and split app UI
- add `JsonTree`, `MappingPanel` and `SearchInput` components
- update `App` to compose new components

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext' and config flags)*

------
https://chatgpt.com/codex/tasks/task_e_6856b1a045ac8324bf79589c32c75f47